### PR TITLE
Fix service metadata layer location check

### DIFF
--- a/feature-service-findings.md
+++ b/feature-service-findings.md
@@ -1,0 +1,192 @@
+# Feature Service Integration - Implementation Findings
+
+## Summary
+
+This document describes the implementation of ArcGIS Feature Service integration and documents a critical fix to the layer discovery process.
+
+## The Problem: Hardcoded Layer Assumption
+
+**Issue**: The earlier implementation (or common mistake) was to assume that Feature Service layers are always accessible at index 0 (e.g., `.../FeatureServer/0`). This is incorrect because:
+
+1. **Layer indices can vary**: A FeatureServer can have multiple layers with different indices (0, 1, 2, etc.)
+2. **Layer 0 might not exist**: Some services start numbering at 1 or have gaps in layer numbering
+3. **Layer 0 might be the wrong layer**: Even if layer 0 exists, it might not be the layer you want
+
+Example of the **WRONG** approach:
+```javascript
+// ❌ WRONG: Blindly assumes layer 0
+const wrongUrl = 'https://services2.arcgis.com/xxx/FeatureServer/0';
+const response = await fetch(`${wrongUrl}/query?...`);
+```
+
+## The Fix: Metadata-Driven Layer Discovery
+
+The correct approach is to query the FeatureServer base URL to get metadata about available layers, then select the appropriate layer.
+
+### Implementation: `discoverFeatureServiceLayer()` Function
+
+Located in `index.html` starting at line ~801, this function:
+
+1. **Queries service metadata**: `GET {baseUrl}?f=json`
+2. **Parses the layers array**: Extracts layer ID, name, and geometry type
+3. **Selects the correct layer**: Either by name match or defaults to first available layer
+4. **Returns layer information**: Including the correct layer index to use
+
+```javascript
+// ✓ CORRECT: Discover layer from metadata
+const layerInfo = await discoverFeatureServiceLayer(serviceUrl);
+const correctUrl = `${serviceUrl}/${layerInfo.layerIndex}`;
+const response = await fetch(`${correctUrl}/query?...`);
+```
+
+### Usage Example
+
+```javascript
+// Query the ETRIMS Roads service
+const serviceUrl = 'https://services2.arcgis.com/saWmpKJIUAjyyNVc/arcgis/rest/services/ETRIMS_Roads_All/FeatureServer';
+
+// Option 1: Let it discover the first layer automatically
+const result = await queryFeatureService(serviceUrl, {
+  bbox: [-90.06, 35.13, -90.03, 35.16],
+  maxRecords: 100
+});
+
+// Option 2: Specify a layer name to find
+const result = await queryFeatureService(serviceUrl, {
+  layerName: 'roads',  // Will search for layer containing 'roads'
+  bbox: [-90.06, 35.13, -90.03, 35.16]
+});
+```
+
+## Implementation Details
+
+### Functions Added (index.html)
+
+1. **`discoverFeatureServiceLayer(serviceUrl, options)`** (line ~801)
+   - Queries service metadata
+   - Finds appropriate layer by name or defaults to first
+   - Returns: `{layerIndex, layerInfo, serviceMetadata}`
+
+2. **`queryFeatureService(serviceUrl, options)`** (line ~874)
+   - Main query function
+   - Auto-discovers layer if URL doesn't have layer index
+   - Builds query parameters (bbox, where clause, outFields, etc.)
+   - Converts ArcGIS JSON to GeoJSON
+   - Returns: `{success, data, error}`
+
+3. **`convertArcGIStoGeoJSON(arcgisJson)`** (line ~966)
+   - Converts ArcGIS REST API format to GeoJSON
+   - Handles features and attributes
+
+4. **`convertArcGISGeometry(arcgisGeom, geometryType)`** (line ~993)
+   - Converts ArcGIS geometry types to GeoJSON geometry
+   - Supports: Point, LineString, MultiLineString, Polygon, MultiPolygon
+
+5. **`testFeatureServiceQuery()`** (line ~2251)
+   - Test/demo function
+   - Tests ETRIMS Roads service
+   - Available in browser console: `window.testFeatureServiceQuery()`
+
+## Testing the Implementation
+
+### Browser Console Test
+
+1. Open the application in a browser
+2. Open Developer Console (F12)
+3. Run the test function:
+
+```javascript
+// Run the built-in test
+await testFeatureServiceQuery()
+
+// Or test manually
+const serviceUrl = 'https://services2.arcgis.com/saWmpKJIUAjyyNVc/arcgis/rest/services/ETRIMS_Roads_All/FeatureServer';
+const result = await queryFeatureService(serviceUrl, {
+  bbox: [-90.06, 35.13, -90.03, 35.16],
+  maxRecords: 5
+});
+console.log(result);
+```
+
+### Expected Test Results
+
+If the service is accessible:
+```
+=== Testing Feature Service Integration ===
+1. Testing metadata discovery...
+✓ Layer discovered: {index: N, name: "...", geometryType: "..."}
+2. Testing feature query...
+✓ Query successful: {featureCount: 5, sampleFeature: {...}}
+=== Test Complete ===
+```
+
+If CORS/authentication issues:
+```
+✗ Failed to discover layer
+Error: Failed to fetch service metadata: 403 Forbidden
+```
+
+## CORS Considerations
+
+**Note**: The ETRIMS service appears to have CORS restrictions or requires authentication. During testing, the service returned a 403 Forbidden error. This means:
+
+1. **Service may not be publicly accessible**: May require authentication token
+2. **CORS headers may not allow browser access**: Service might need to be configured to allow cross-origin requests
+3. **Possible solutions**:
+   - Request IT to make the service public and CORS-enabled
+   - Use a proxy server to handle CORS
+   - Request an API token and include it in queries
+
+## Query Parameters Supported
+
+The `queryFeatureService()` function supports:
+
+- **`bbox`**: `[minX, minY, maxX, maxY]` - Spatial filter
+- **`where`**: SQL where clause (default: `"1=1"`)
+- **`outFields`**: Array of field names to return (default: `["*"]`)
+- **`maxRecords`**: Maximum features to return
+- **`layerName`**: Layer name to search for (optional)
+
+## Coordinate System
+
+The implementation requests WGS84 (EPSG:4326) coordinates using the `outSR=4326` parameter. This ensures compatibility with the existing Leaflet/GeoJSON infrastructure which uses WGS84.
+
+## Key Differences from Incorrect Implementation
+
+| Aspect | ❌ Wrong Approach | ✓ Correct Approach |
+|--------|------------------|-------------------|
+| Layer discovery | Hardcoded `/0` | Query metadata, discover layer |
+| Flexibility | Breaks if layer 0 doesn't exist | Works with any layer structure |
+| Layer selection | No choice | Can select by name or default to first |
+| Error handling | Fails silently | Returns detailed error messages |
+| Logging | None | Console logs show discovery process |
+
+## Files Modified
+
+- **`index.html`**: Added Feature Service query functions (lines ~790-1037, ~2236-2295)
+
+## Files Created
+
+- **`feature-service-findings.md`**: This document
+
+## Next Steps (Out of Scope for This Fix)
+
+Per the spec, the following are planned but not yet implemented:
+
+1. Integration with the UI to display functional classification results
+2. Adding functional class to PDF report
+3. Pagination support for large result sets
+4. Refactoring existing datasets to use configuration-driven approach
+5. Full integration with spatial analysis functions
+
+## References
+
+- Feature Service Integration Spec: `feature-service-integration-spec.md`
+- ArcGIS REST API Documentation: https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
+- Test Service: https://services2.arcgis.com/saWmpKJIUAjyyNVc/arcgis/rest/services/ETRIMS_Roads_All/FeatureServer
+
+## Conclusion
+
+The implementation now properly discovers layer indices from service metadata instead of making incorrect assumptions. This makes the code more robust and able to work with any properly configured ArcGIS FeatureServer, regardless of its layer structure.
+
+To verify the fix works once CORS/authentication issues are resolved, use the `testFeatureServiceQuery()` function available in the browser console.

--- a/index.html
+++ b/index.html
@@ -788,6 +788,255 @@
     }
 
     // ============================================
+    // FEATURE SERVICE QUERY
+    // ============================================
+
+    /**
+     * Discover the correct layer from a FeatureServer by querying its metadata
+     * @param {string} serviceUrl - The base FeatureServer URL (without /N at the end)
+     * @param {Object} options - Discovery options
+     * @param {string} options.layerName - Optional layer name to match (case-insensitive)
+     * @returns {Promise<Object>} - Object with {layerIndex, layerInfo} or null if not found
+     */
+    async function discoverFeatureServiceLayer(serviceUrl, options = {}) {
+      try {
+        // Remove trailing slash if present
+        const baseUrl = serviceUrl.replace(/\/$/, '');
+
+        // Query the service metadata
+        const metadataUrl = `${baseUrl}?f=json`;
+        console.log('Fetching service metadata from:', metadataUrl);
+
+        const response = await fetch(metadataUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch service metadata: ${response.status} ${response.statusText}`);
+        }
+
+        const metadata = await response.json();
+
+        // Check for error in response
+        if (metadata.error) {
+          throw new Error(`Service error: ${metadata.error.message || JSON.stringify(metadata.error)}`);
+        }
+
+        // Get layers from metadata
+        const layers = metadata.layers || [];
+        console.log('Available layers:', layers.map(l => ({ id: l.id, name: l.name })));
+
+        if (layers.length === 0) {
+          console.warn('No layers found in service metadata');
+          return null;
+        }
+
+        // If a specific layer name is requested, find it
+        if (options.layerName) {
+          const targetName = options.layerName.toLowerCase();
+          const matchedLayer = layers.find(layer =>
+            layer.name && layer.name.toLowerCase().includes(targetName)
+          );
+
+          if (matchedLayer) {
+            console.log(`Found matching layer: ${matchedLayer.name} (ID: ${matchedLayer.id})`);
+            return {
+              layerIndex: matchedLayer.id,
+              layerInfo: matchedLayer,
+              serviceMetadata: metadata
+            };
+          }
+        }
+
+        // Default to first layer if no specific name requested
+        const firstLayer = layers[0];
+        console.log(`Using first layer: ${firstLayer.name} (ID: ${firstLayer.id})`);
+        return {
+          layerIndex: firstLayer.id,
+          layerInfo: firstLayer,
+          serviceMetadata: metadata
+        };
+
+      } catch (error) {
+        console.error('Error discovering feature service layer:', error);
+        return null;
+      }
+    }
+
+    /**
+     * Query an ArcGIS Feature Service and return results as GeoJSON
+     * @param {string} serviceUrl - The Feature Service URL (can be base URL or layer-specific)
+     * @param {Object} options - Query options
+     * @param {Array} options.bbox - Bounding box [minX, minY, maxX, maxY] in WGS84
+     * @param {string} options.where - SQL where clause (default: "1=1")
+     * @param {Array} options.outFields - Fields to return (default: ["*"])
+     * @param {number} options.maxRecords - Max features to return (default: 1000)
+     * @param {string} options.layerName - Optional layer name to discover (if serviceUrl is base URL)
+     * @returns {Promise<Object>} - {success, data (GeoJSON FeatureCollection), error}
+     */
+    async function queryFeatureService(serviceUrl, options = {}) {
+      try {
+        let queryUrl = serviceUrl;
+
+        // Check if the URL already has a layer index (ends with /N)
+        const hasLayerIndex = /\/\d+\/?$/.test(serviceUrl);
+
+        if (!hasLayerIndex) {
+          // Need to discover the layer first
+          console.log('No layer index found in URL, discovering layer...');
+          const layerInfo = await discoverFeatureServiceLayer(serviceUrl, {
+            layerName: options.layerName
+          });
+
+          if (!layerInfo) {
+            throw new Error('Could not discover layer from service metadata');
+          }
+
+          // Construct the layer-specific URL
+          queryUrl = `${serviceUrl.replace(/\/$/, '')}/${layerInfo.layerIndex}`;
+          console.log('Discovered layer URL:', queryUrl);
+        }
+
+        // Build query parameters
+        const params = new URLSearchParams({
+          where: options.where || '1=1',
+          outFields: options.outFields ? options.outFields.join(',') : '*',
+          returnGeometry: 'true',
+          outSR: '4326',  // Request WGS84 coordinates
+          f: 'json'
+        });
+
+        // Add bounding box if provided
+        if (options.bbox && options.bbox.length === 4) {
+          const [minX, minY, maxX, maxY] = options.bbox;
+          params.append('geometry', JSON.stringify({
+            xmin: minX,
+            ymin: minY,
+            xmax: maxX,
+            ymax: maxY
+          }));
+          params.append('geometryType', 'esriGeometryEnvelope');
+          params.append('spatialRel', 'esriSpatialRelIntersects');
+        }
+
+        // Add max records limit
+        if (options.maxRecords) {
+          params.append('resultRecordCount', options.maxRecords);
+        }
+
+        // Execute query
+        const fullQueryUrl = `${queryUrl}/query?${params.toString()}`;
+        console.log('Querying Feature Service:', fullQueryUrl);
+
+        const response = await fetch(fullQueryUrl);
+        if (!response.ok) {
+          throw new Error(`Query failed: ${response.status} ${response.statusText}`);
+        }
+
+        const arcgisJson = await response.json();
+
+        // Check for error in response
+        if (arcgisJson.error) {
+          throw new Error(`Query error: ${arcgisJson.error.message || JSON.stringify(arcgisJson.error)}`);
+        }
+
+        // Convert ArcGIS JSON to GeoJSON
+        const geojson = convertArcGIStoGeoJSON(arcgisJson);
+
+        console.log(`Query successful: ${geojson.features.length} features returned`);
+
+        return {
+          success: true,
+          data: geojson,
+          error: null
+        };
+
+      } catch (error) {
+        console.error('Feature Service query error:', error);
+        return {
+          success: false,
+          data: null,
+          error: error.message
+        };
+      }
+    }
+
+    /**
+     * Convert ArcGIS JSON format to GeoJSON format
+     * @param {Object} arcgisJson - ArcGIS REST API response
+     * @returns {Object} - GeoJSON FeatureCollection
+     */
+    function convertArcGIStoGeoJSON(arcgisJson) {
+      const features = (arcgisJson.features || []).map(arcgisFeature => {
+        // Convert geometry
+        const geometry = convertArcGISGeometry(
+          arcgisFeature.geometry,
+          arcgisJson.geometryType
+        );
+
+        return {
+          type: 'Feature',
+          properties: arcgisFeature.attributes || {},
+          geometry: geometry
+        };
+      });
+
+      return {
+        type: 'FeatureCollection',
+        features: features
+      };
+    }
+
+    /**
+     * Convert ArcGIS geometry to GeoJSON geometry
+     * @param {Object} arcgisGeom - ArcGIS geometry object
+     * @param {string} geometryType - ArcGIS geometry type
+     * @returns {Object} - GeoJSON geometry
+     */
+    function convertArcGISGeometry(arcgisGeom, geometryType) {
+      if (!arcgisGeom) return null;
+
+      switch (geometryType) {
+        case 'esriGeometryPoint':
+          return {
+            type: 'Point',
+            coordinates: [arcgisGeom.x, arcgisGeom.y]
+          };
+
+        case 'esriGeometryPolyline':
+          // ArcGIS polylines can have multiple paths
+          if (arcgisGeom.paths && arcgisGeom.paths.length === 1) {
+            return {
+              type: 'LineString',
+              coordinates: arcgisGeom.paths[0]
+            };
+          } else if (arcgisGeom.paths && arcgisGeom.paths.length > 1) {
+            return {
+              type: 'MultiLineString',
+              coordinates: arcgisGeom.paths
+            };
+          }
+          return null;
+
+        case 'esriGeometryPolygon':
+          // ArcGIS polygons can have multiple rings
+          if (arcgisGeom.rings && arcgisGeom.rings.length === 1) {
+            return {
+              type: 'Polygon',
+              coordinates: arcgisGeom.rings
+            };
+          } else if (arcgisGeom.rings && arcgisGeom.rings.length > 1) {
+            return {
+              type: 'MultiPolygon',
+              coordinates: [arcgisGeom.rings]
+            };
+          }
+          return null;
+
+        default:
+          console.warn('Unknown geometry type:', geometryType);
+          return null;
+      }
+    }
+
+    // ============================================
     // DATA LOADING
     // ============================================
 
@@ -1983,6 +2232,67 @@
         overlay.style.display = 'none';
       }
     }
+
+    // ============================================
+    // FEATURE SERVICE TESTING (for development/debugging)
+    // ============================================
+
+    /**
+     * Test function for Feature Service integration
+     * This demonstrates how to properly query the ETRIMS roads service
+     *
+     * KEY FIX: This implementation properly discovers the layer index from service metadata
+     * instead of blindly assuming layer 0. The discoverFeatureServiceLayer() function
+     * queries the FeatureServer base URL to get metadata about available layers, then
+     * uses the correct layer index.
+     *
+     * Usage: Call testFeatureServiceQuery() from browser console to test
+     */
+    async function testFeatureServiceQuery() {
+      console.log('=== Testing Feature Service Integration ===');
+
+      // Test service URL (ETRIMS Roads)
+      const serviceUrl = 'https://services2.arcgis.com/saWmpKJIUAjyyNVc/arcgis/rest/services/ETRIMS_Roads_All/FeatureServer';
+
+      // Test bbox (downtown Memphis area as specified in spec)
+      const testBbox = [-90.06, 35.13, -90.03, 35.16];
+
+      console.log('1. Testing metadata discovery...');
+      const layerInfo = await discoverFeatureServiceLayer(serviceUrl);
+      if (layerInfo) {
+        console.log('✓ Layer discovered:', {
+          index: layerInfo.layerIndex,
+          name: layerInfo.layerInfo.name,
+          geometryType: layerInfo.layerInfo.geometryType
+        });
+      } else {
+        console.error('✗ Failed to discover layer');
+        return;
+      }
+
+      console.log('2. Testing feature query...');
+      const result = await queryFeatureService(serviceUrl, {
+        bbox: testBbox,
+        maxRecords: 5
+      });
+
+      if (result.success) {
+        console.log('✓ Query successful:', {
+          featureCount: result.data.features.length,
+          sampleFeature: result.data.features[0]
+        });
+      } else {
+        console.error('✗ Query failed:', result.error);
+      }
+
+      console.log('=== Test Complete ===');
+      return result;
+    }
+
+    // Make test function available in console for debugging
+    window.testFeatureServiceQuery = testFeatureServiceQuery;
+    window.queryFeatureService = queryFeatureService;
+    window.discoverFeatureServiceLayer = discoverFeatureServiceLayer;
 
     // ============================================
     // START APPLICATION


### PR DESCRIPTION
…rver

Previous approach incorrectly assumed layer 0 would always exist. This implementation properly queries the FeatureServer metadata to discover the correct layer index before making queries.

Key changes:
- Added discoverFeatureServiceLayer() to query service metadata and find layers
- Added queryFeatureService() with automatic layer discovery
- Added convertArcGIStoGeoJSON() to convert ArcGIS format to GeoJSON
- Added convertArcGISGeometry() to handle all geometry types
- Added testFeatureServiceQuery() for testing and debugging
- Created feature-service-findings.md documenting the fix

The implementation now:
1. Queries FeatureServer base URL for metadata
2. Parses available layers from metadata
3. Selects appropriate layer by name or defaults to first
4. Constructs correct layer URL with discovered index
5. Properly converts ArcGIS JSON responses to GeoJSON

This fixes the issue where hardcoded /0 layer assumption would fail for services where layer 0 doesn't exist or is not the intended layer.