### PR TITLE
Fix corridor detection false positives from perpendicular crossings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1969,9 +1969,84 @@
     }
 
     /**
+     * Calculate the length of a line segment that falls inside a polygon buffer.
+     * Uses polygon boundary intersection to find exact entry/exit points.
+     * This fixes the false positive issue where perpendicular crossings were
+     * counting the full segment length instead of just the portion inside.
+     *
+     * @param {Object} segment - Turf.js LineString (2 coordinates)
+     * @param {Object} buffer - Turf.js Polygon (the corridor buffer)
+     * @returns {number} Length in feet of segment inside the buffer
+     */
+    function measureSegmentInsideBuffer(segment, buffer) {
+      const coords = turf.getCoords(segment);
+      if (coords.length < 2) return 0;
+
+      const startPt = turf.point(coords[0]);
+      const endPt = turf.point(coords[coords.length - 1]);
+      const segmentLength = turf.length(segment, { units: 'feet' });
+
+      if (segmentLength === 0) return 0;
+
+      const startInside = turf.booleanPointInPolygon(startPt, buffer);
+      const endInside = turf.booleanPointInPolygon(endPt, buffer);
+
+      // Case 1: Both endpoints inside - entire segment is inside
+      if (startInside && endInside) {
+        return segmentLength;
+      }
+
+      // Find where segment crosses buffer boundary
+      const bufferBoundary = turf.polygonToLine(buffer);
+      const intersections = turf.lineIntersect(segment, bufferBoundary);
+
+      // Case 2: No boundary crossings
+      if (intersections.features.length === 0) {
+        // If start is inside but no crossings, entire segment must be inside
+        // (This handles numerical edge cases near boundary)
+        return startInside ? segmentLength : 0;
+      }
+
+      // Calculate distance along segment for each intersection point
+      const distances = [];
+      for (const pt of intersections.features) {
+        // Find the nearest point on the segment to this intersection
+        const nearest = turf.nearestPointOnLine(segment, pt, { units: 'feet' });
+        distances.push(nearest.properties.location);
+      }
+
+      // Sort distances from start to end
+      distances.sort((a, b) => a - b);
+
+      // Walk along segment, tracking inside/outside state
+      let totalInside = 0;
+      let inside = startInside;
+      let prevDist = 0;
+
+      for (const dist of distances) {
+        if (inside) {
+          totalInside += dist - prevDist;
+        }
+        prevDist = dist;
+        inside = !inside; // Toggle at each boundary crossing
+      }
+
+      // Handle final segment from last crossing to end
+      if (inside) {
+        totalInside += segmentLength - prevDist;
+      }
+
+      return Math.max(0, totalInside); // Ensure non-negative
+    }
+
+    /**
      * Analyze corridor match for LineString datasets
-     * Works for any LineString dataset with corridor matching logic
-     * Uses turf.lineOverlap() for accurate overlap detection
+     * Works for any LineString dataset with corridor matching logic.
+     * Uses buffer intersection with segment clipping to accurately measure
+     * the portion of each route segment inside the corridor buffer.
+     * This correctly handles perpendicular crossings (only counts the
+     * portion inside the buffer, not the full segment length).
+     *
      * @param {Object} drawnGeometry - GeoJSON geometry (LineString or Point)
      * @param {Object} datasetConfig - Configuration object from DATASETS
      * @param {Object} geoJsonData - GeoJSON FeatureCollection to analyze
@@ -2040,11 +2115,15 @@
               for (let i = 0; i < routeCoords.length - 1; i++) {
                 const segment = turf.lineString([routeCoords[i], routeCoords[i + 1]]);
 
-                // Check if segment intersects the corridor buffer
-                if (turf.booleanIntersects(segment, corridorBuffer)) {
-                  // Add segment length to total
-                  totalOverlap += turf.length(segment, { units: 'feet' });
+                // Quick check: skip if segment doesn't intersect buffer at all
+                if (!turf.booleanIntersects(segment, corridorBuffer)) {
+                  continue;
                 }
+
+                // FIX: Calculate actual length inside buffer, not full segment length
+                // This prevents false positives from perpendicular crossings
+                const insideLength = measureSegmentInsideBuffer(segment, corridorBuffer);
+                totalOverlap += insideLength;
               }
 
               // Early exit optimization: if we've already met the threshold, no need to continue

--- a/test-corridor-detection.html
+++ b/test-corridor-detection.html
@@ -1,0 +1,615 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Corridor Detection Algorithm Test Suite</title>
+    <script src="https://unpkg.com/@turf/turf@6.5.0/turf.min.js"></script>
+    <style>
+        body {
+            font-family: 'Consolas', 'Monaco', monospace;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #1a1a1a;
+            color: #e0e0e0;
+        }
+        h1, h2, h3 { color: #4fc3f7; }
+        .test-suite { margin-bottom: 30px; border: 1px solid #333; padding: 15px; border-radius: 5px; }
+        .test-case { margin: 10px 0; padding: 10px; background: #252525; border-radius: 3px; }
+        .pass { border-left: 4px solid #4caf50; }
+        .fail { border-left: 4px solid #f44336; }
+        .test-name { font-weight: bold; }
+        .test-details { font-size: 12px; color: #888; margin-top: 5px; }
+        .expected { color: #4caf50; }
+        .actual { color: #ff9800; }
+        .summary {
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 5px;
+            font-size: 18px;
+        }
+        .summary.all-pass { background: #1b5e20; }
+        .summary.has-fail { background: #b71c1c; }
+        pre { background: #0a0a0a; padding: 10px; overflow-x: auto; font-size: 11px; }
+        .visualization {
+            display: inline-block;
+            margin: 10px 0;
+            padding: 10px;
+            background: #0a0a0a;
+            border-radius: 3px;
+        }
+        canvas { display: block; }
+    </style>
+</head>
+<body>
+    <h1>Corridor Detection Algorithm Test Suite</h1>
+    <p>Testing the algorithm that detects when a user-drawn project line runs parallel to transportation routes.</p>
+
+    <div id="summary" class="summary"></div>
+    <div id="results"></div>
+
+    <script>
+        // ============================================
+        // HELPER FUNCTIONS (from index.html)
+        // ============================================
+
+        function normalizeToLineStrings(feature) {
+            const geom = feature.geometry || feature;
+            if (geom.type === 'LineString') {
+                return [turf.lineString(geom.coordinates)];
+            } else if (geom.type === 'MultiLineString') {
+                return geom.coordinates.map(coords => turf.lineString(coords));
+            }
+            return [];
+        }
+
+        // ============================================
+        // CURRENT ALGORITHM (BROKEN)
+        // This is the current implementation that has false positives
+        // ============================================
+
+        function analyzeCorridorMatch_CURRENT(drawnGeometry, bufferDistance, minSharedLength, routeFeature) {
+            const geometry = drawnGeometry.type === 'Feature' ? drawnGeometry.geometry : drawnGeometry;
+
+            if (geometry.type !== 'LineString') return { match: false, overlap: 0 };
+
+            const corridorBuffer = turf.buffer(geometry, bufferDistance, { units: 'feet' });
+
+            if (!turf.booleanIntersects(corridorBuffer, routeFeature)) {
+                return { match: false, overlap: 0 };
+            }
+
+            const routeLines = normalizeToLineStrings(routeFeature);
+            let totalOverlap = 0;
+
+            for (const routeLine of routeLines) {
+                const routeCoords = turf.getCoords(routeLine);
+                for (let i = 0; i < routeCoords.length - 1; i++) {
+                    const segment = turf.lineString([routeCoords[i], routeCoords[i + 1]]);
+
+                    // BUG: Adds FULL segment length, not just portion inside buffer
+                    if (turf.booleanIntersects(segment, corridorBuffer)) {
+                        totalOverlap += turf.length(segment, { units: 'feet' });
+                    }
+                }
+            }
+
+            return {
+                match: totalOverlap >= minSharedLength,
+                overlap: totalOverlap
+            };
+        }
+
+        // ============================================
+        // PROPOSED FIX: Segment Clipping Algorithm
+        // ============================================
+
+        /**
+         * Calculate the length of a line segment that falls inside a polygon buffer.
+         * Uses polygon boundary intersection to find exact entry/exit points.
+         *
+         * @param {Object} segment - Turf.js LineString (2 coordinates)
+         * @param {Object} buffer - Turf.js Polygon (the corridor buffer)
+         * @returns {number} Length in feet of segment inside the buffer
+         */
+        function measureSegmentInsideBuffer(segment, buffer) {
+            const coords = turf.getCoords(segment);
+            if (coords.length < 2) return 0;
+
+            const startPt = turf.point(coords[0]);
+            const endPt = turf.point(coords[coords.length - 1]);
+            const segmentLength = turf.length(segment, { units: 'feet' });
+
+            if (segmentLength === 0) return 0;
+
+            const startInside = turf.booleanPointInPolygon(startPt, buffer);
+            const endInside = turf.booleanPointInPolygon(endPt, buffer);
+
+            // Case 1: Both endpoints inside - entire segment is inside
+            if (startInside && endInside) {
+                return segmentLength;
+            }
+
+            // Find where segment crosses buffer boundary
+            const bufferBoundary = turf.polygonToLine(buffer);
+            const intersections = turf.lineIntersect(segment, bufferBoundary);
+
+            // Case 2: No boundary crossings
+            if (intersections.features.length === 0) {
+                // If start is inside but no crossings, entire segment must be inside
+                // (This handles numerical edge cases near boundary)
+                return startInside ? segmentLength : 0;
+            }
+
+            // Calculate distance along segment for each intersection point
+            const distances = [];
+            for (const pt of intersections.features) {
+                // Find the nearest point on the segment to this intersection
+                const nearest = turf.nearestPointOnLine(segment, pt, { units: 'feet' });
+                distances.push(nearest.properties.location);
+            }
+
+            // Sort distances from start to end
+            distances.sort((a, b) => a - b);
+
+            // Walk along segment, tracking inside/outside state
+            let totalInside = 0;
+            let inside = startInside;
+            let prevDist = 0;
+
+            for (const dist of distances) {
+                if (inside) {
+                    totalInside += dist - prevDist;
+                }
+                prevDist = dist;
+                inside = !inside; // Toggle at each boundary crossing
+            }
+
+            // Handle final segment from last crossing to end
+            if (inside) {
+                totalInside += segmentLength - prevDist;
+            }
+
+            return Math.max(0, totalInside); // Ensure non-negative
+        }
+
+        /**
+         * Fixed corridor match analysis using segment clipping
+         */
+        function analyzeCorridorMatch_FIXED(drawnGeometry, bufferDistance, minSharedLength, routeFeature) {
+            const geometry = drawnGeometry.type === 'Feature' ? drawnGeometry.geometry : drawnGeometry;
+
+            if (geometry.type !== 'LineString') return { match: false, overlap: 0 };
+
+            const corridorBuffer = turf.buffer(geometry, bufferDistance, { units: 'feet' });
+
+            // Quick rejection: no intersection at all
+            if (!turf.booleanIntersects(corridorBuffer, routeFeature)) {
+                return { match: false, overlap: 0 };
+            }
+
+            const routeLines = normalizeToLineStrings(routeFeature);
+            let totalOverlap = 0;
+
+            for (const routeLine of routeLines) {
+                const routeCoords = turf.getCoords(routeLine);
+
+                for (let i = 0; i < routeCoords.length - 1; i++) {
+                    const segment = turf.lineString([routeCoords[i], routeCoords[i + 1]]);
+
+                    // Quick check: skip if segment doesn't intersect buffer at all
+                    if (!turf.booleanIntersects(segment, corridorBuffer)) {
+                        continue;
+                    }
+
+                    // FIX: Calculate actual length inside buffer, not full segment
+                    const insideLength = measureSegmentInsideBuffer(segment, corridorBuffer);
+                    totalOverlap += insideLength;
+                }
+
+                // Early exit if threshold met
+                if (totalOverlap >= minSharedLength) {
+                    break;
+                }
+            }
+
+            return {
+                match: totalOverlap >= minSharedLength,
+                overlap: totalOverlap
+            };
+        }
+
+        // ============================================
+        // TEST UTILITIES
+        // ============================================
+
+        /**
+         * Create a horizontal line (east-west) at given latitude
+         */
+        function createEWLine(centerLon, lat, lengthFeet) {
+            // Approximate: 1 degree longitude ≈ 288,200 feet at 35°N latitude
+            const degreesPerFoot = 1 / 288200;
+            const halfLength = (lengthFeet / 2) * degreesPerFoot;
+            return turf.lineString([
+                [centerLon - halfLength, lat],
+                [centerLon + halfLength, lat]
+            ]);
+        }
+
+        /**
+         * Create a vertical line (north-south) at given longitude
+         */
+        function createNSLine(lon, centerLat, lengthFeet) {
+            // Approximate: 1 degree latitude ≈ 364,000 feet
+            const degreesPerFoot = 1 / 364000;
+            const halfLength = (lengthFeet / 2) * degreesPerFoot;
+            return turf.lineString([
+                [lon, centerLat - halfLength],
+                [lon, centerLat + halfLength]
+            ]);
+        }
+
+        /**
+         * Create an angled line
+         */
+        function createAngledLine(startLon, startLat, lengthFeet, angleDegrees) {
+            const lonDegreesPerFoot = 1 / 288200;
+            const latDegreesPerFoot = 1 / 364000;
+            const angleRad = (angleDegrees * Math.PI) / 180;
+
+            const dx = Math.cos(angleRad) * lengthFeet * lonDegreesPerFoot;
+            const dy = Math.sin(angleRad) * lengthFeet * latDegreesPerFoot;
+
+            return turf.lineString([
+                [startLon, startLat],
+                [startLon + dx, startLat + dy]
+            ]);
+        }
+
+        /**
+         * Offset a line by a perpendicular distance (in feet)
+         */
+        function offsetLine(line, offsetFeet, direction = 'north') {
+            const coords = turf.getCoords(line);
+            const latDegreesPerFoot = 1 / 364000;
+            const lonDegreesPerFoot = 1 / 288200;
+
+            const offset = direction === 'north' || direction === 'south'
+                ? offsetFeet * latDegreesPerFoot * (direction === 'north' ? 1 : -1)
+                : offsetFeet * lonDegreesPerFoot * (direction === 'east' ? 1 : -1);
+
+            const newCoords = coords.map(coord => {
+                if (direction === 'north' || direction === 'south') {
+                    return [coord[0], coord[1] + offset];
+                } else {
+                    return [coord[0] + offset, coord[1]];
+                }
+            });
+
+            return turf.lineString(newCoords);
+        }
+
+        // ============================================
+        // TEST CASES
+        // ============================================
+
+        const TEST_CASES = [
+            // ========== PARALLEL ROUTES (SHOULD MATCH) ==========
+            {
+                name: "Parallel route 50ft away, 800ft overlap",
+                description: "Route runs parallel to project, 50ft offset, for 800ft",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 1000);
+                    const route = offsetLine(createEWLine(-90.0, 35.0, 800), 50, 'north');
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: true,
+                expectedOverlapMin: 700, // Should be close to 800ft
+                expectedOverlapMax: 850
+            },
+            {
+                name: "Parallel route entirely within buffer (30ft offset)",
+                description: "Route runs parallel and very close (30ft), entire 500ft inside buffer",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 600);
+                    const route = offsetLine(createEWLine(-90.0, 35.0, 500), 30, 'north');
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: true,
+                expectedOverlapMin: 480,
+                expectedOverlapMax: 520
+            },
+            {
+                name: "Parallel route at edge of buffer (90ft offset)",
+                description: "Route runs parallel at nearly the buffer edge",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 600);
+                    const route = offsetLine(createEWLine(-90.0, 35.0, 500), 90, 'north');
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: true,
+                expectedOverlapMin: 400,
+                expectedOverlapMax: 520
+            },
+
+            // ========== PERPENDICULAR CROSSINGS (SHOULD NOT MATCH) ==========
+            {
+                name: "Perpendicular crossing - short route (200ft)",
+                description: "North-south route crosses east-west project at 90 degrees",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 500);
+                    const route = createNSLine(-90.0, 35.0, 200);
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: false,
+                expectedOverlapMin: 0,
+                expectedOverlapMax: 250 // Should be ~200ft (buffer width)
+            },
+            {
+                name: "Perpendicular crossing - long route (500ft) - THE BUG CASE",
+                description: "Long N-S route crosses E-W project. Current algorithm counts 500ft, should count ~200ft",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 500);
+                    const route = createNSLine(-90.0, 35.0, 500);
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: false,
+                expectedOverlapMin: 0,
+                expectedOverlapMax: 250 // Should be ~200ft (buffer width), NOT 500ft
+            },
+            {
+                name: "Perpendicular crossing - very long route (1000ft)",
+                description: "Very long N-S route crosses project. Should only count portion inside buffer",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 500);
+                    const route = createNSLine(-90.0, 35.0, 1000);
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: false,
+                expectedOverlapMin: 0,
+                expectedOverlapMax: 250 // Should be ~200ft
+            },
+            {
+                name: "Multiple perpendicular crossings",
+                description: "Two separate N-S segments cross the project",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 1000);
+                    // Two vertical segments crossing at different points
+                    const route = turf.featureCollection([
+                        turf.feature({
+                            type: 'MultiLineString',
+                            coordinates: [
+                                // First crossing at -90.001
+                                [[-90.001, 34.999], [-90.001, 35.001]],
+                                // Second crossing at -89.999
+                                [[-89.999, 34.999], [-89.999, 35.001]]
+                            ]
+                        })
+                    ]).features[0];
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: false,
+                expectedOverlapMin: 0,
+                expectedOverlapMax: 450 // Two crossings ~200ft each, still under 500ft total
+            },
+
+            // ========== ANGLED APPROACHES (EDGE CASES) ==========
+            {
+                name: "45-degree angle approach - 600ft segment",
+                description: "Route approaches at 45 degrees, should count diagonal portion inside buffer",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 500);
+                    const route = createAngledLine(-90.001, 34.999, 600, 45);
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: false, // 45° crossing is mostly passing through
+                expectedOverlapMin: 0,
+                expectedOverlapMax: 350 // Diagonal crossing ~280ft
+            },
+            {
+                name: "30-degree approach - significant parallel component",
+                description: "Route at shallow angle has more parallel component",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 800);
+                    const route = createAngledLine(-90.002, 35.0001, 700, 15);
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: true, // Shallow angle means more overlap
+                expectedOverlapMin: 300,
+                expectedOverlapMax: 700
+            },
+
+            // ========== EDGE CASES ==========
+            {
+                name: "Route entirely outside buffer",
+                description: "Route is 200ft away from project (outside 100ft buffer)",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 500);
+                    const route = offsetLine(createEWLine(-90.0, 35.0, 500), 200, 'north');
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: false,
+                expectedOverlapMin: 0,
+                expectedOverlapMax: 0
+            },
+            {
+                name: "Short parallel segment (100ft) - below threshold",
+                description: "Parallel route for only 100ft (below 300ft minimum)",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 500);
+                    const route = offsetLine(createEWLine(-90.0, 35.0, 100), 30, 'north');
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: false,
+                expectedOverlapMin: 50,
+                expectedOverlapMax: 150
+            },
+            {
+                name: "Route starts inside buffer, exits, and never returns",
+                description: "Route segment that starts parallel then veers away",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 500);
+                    // Route starts parallel then angles away
+                    const route = turf.lineString([
+                        [-90.001, 35.00005],  // ~18ft north, inside buffer
+                        [-89.999, 35.00005],  // Runs parallel for ~580ft
+                        [-89.998, 35.002]     // Then angles sharply north
+                    ]);
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: true,
+                expectedOverlapMin: 400,
+                expectedOverlapMax: 700
+            },
+            {
+                name: "MultiLineString with mixed segments",
+                description: "Some segments parallel, some perpendicular",
+                setup: () => {
+                    const project = createEWLine(-90.0, 35.0, 1000);
+                    const route = turf.feature({
+                        type: 'MultiLineString',
+                        coordinates: [
+                            // Parallel segment (400ft) - 30ft offset
+                            [[-90.001, 35.00008], [-89.9996, 35.00008]],
+                            // Perpendicular segment (500ft crossing)
+                            [[-89.998, 34.999], [-89.998, 35.001]]
+                        ]
+                    });
+                    return { project, route };
+                },
+                bufferDistance: 100,
+                minSharedLength: 300,
+                expectedMatch: true, // 400ft parallel + ~200ft from crossing > 300ft
+                expectedOverlapMin: 350,
+                expectedOverlapMax: 650
+            }
+        ];
+
+        // ============================================
+        // TEST RUNNER
+        // ============================================
+
+        function runTests() {
+            const results = [];
+            const resultsDiv = document.getElementById('results');
+            resultsDiv.innerHTML = '';
+
+            for (const testCase of TEST_CASES) {
+                const { project, route } = testCase.setup();
+
+                // Run both algorithms
+                const currentResult = analyzeCorridorMatch_CURRENT(
+                    project,
+                    testCase.bufferDistance,
+                    testCase.minSharedLength,
+                    route
+                );
+
+                const fixedResult = analyzeCorridorMatch_FIXED(
+                    project,
+                    testCase.bufferDistance,
+                    testCase.minSharedLength,
+                    route
+                );
+
+                // Determine pass/fail for fixed algorithm
+                const matchCorrect = fixedResult.match === testCase.expectedMatch;
+                const overlapInRange = fixedResult.overlap >= testCase.expectedOverlapMin &&
+                                       fixedResult.overlap <= testCase.expectedOverlapMax;
+                const passed = matchCorrect && overlapInRange;
+
+                // Current algorithm behavior
+                const currentMatchCorrect = currentResult.match === testCase.expectedMatch;
+                const currentOverlapInRange = currentResult.overlap >= testCase.expectedOverlapMin &&
+                                              currentResult.overlap <= testCase.expectedOverlapMax;
+                const currentPassed = currentMatchCorrect && currentOverlapInRange;
+
+                results.push({
+                    ...testCase,
+                    currentResult,
+                    fixedResult,
+                    passed,
+                    currentPassed,
+                    matchCorrect,
+                    overlapInRange
+                });
+
+                // Render result
+                const div = document.createElement('div');
+                div.className = `test-case ${passed ? 'pass' : 'fail'}`;
+                div.innerHTML = `
+                    <div class="test-name">${passed ? '✓' : '✗'} ${testCase.name}</div>
+                    <div class="test-details">${testCase.description}</div>
+                    <div class="test-details">
+                        <strong>Expected:</strong>
+                        <span class="expected">
+                            match=${testCase.expectedMatch},
+                            overlap=${testCase.expectedOverlapMin}-${testCase.expectedOverlapMax}ft
+                        </span>
+                    </div>
+                    <div class="test-details">
+                        <strong>Current (broken):</strong>
+                        <span class="actual" style="color: ${currentPassed ? '#4caf50' : '#f44336'}">
+                            match=${currentResult.match},
+                            overlap=${currentResult.overlap.toFixed(1)}ft
+                            ${currentPassed ? '✓' : '✗'}
+                        </span>
+                    </div>
+                    <div class="test-details">
+                        <strong>Fixed:</strong>
+                        <span class="actual" style="color: ${passed ? '#4caf50' : '#f44336'}">
+                            match=${fixedResult.match},
+                            overlap=${fixedResult.overlap.toFixed(1)}ft
+                            ${passed ? '✓' : '✗'}
+                        </span>
+                    </div>
+                `;
+                resultsDiv.appendChild(div);
+            }
+
+            // Summary
+            const totalTests = results.length;
+            const fixedPassed = results.filter(r => r.passed).length;
+            const currentPassed = results.filter(r => r.currentPassed).length;
+
+            const summaryDiv = document.getElementById('summary');
+            summaryDiv.className = `summary ${fixedPassed === totalTests ? 'all-pass' : 'has-fail'}`;
+            summaryDiv.innerHTML = `
+                <strong>Test Results:</strong><br>
+                Current Algorithm: ${currentPassed}/${totalTests} passing<br>
+                Fixed Algorithm: ${fixedPassed}/${totalTests} passing
+            `;
+
+            return results;
+        }
+
+        // Run tests on page load
+        window.onload = runTests;
+    </script>
+</body>
+</html>

--- a/test-corridor-node.js
+++ b/test-corridor-node.js
@@ -1,0 +1,400 @@
+/**
+ * Node.js test runner for corridor detection algorithm
+ * Run with: node test-corridor-node.js
+ */
+
+const turf = require('@turf/turf');
+
+// ============================================
+// HELPER FUNCTIONS (from index.html)
+// ============================================
+
+function normalizeToLineStrings(feature) {
+    const geom = feature.geometry || feature;
+    if (geom.type === 'LineString') {
+        return [turf.lineString(geom.coordinates)];
+    } else if (geom.type === 'MultiLineString') {
+        return geom.coordinates.map(coords => turf.lineString(coords));
+    }
+    return [];
+}
+
+// ============================================
+// CURRENT ALGORITHM (BROKEN)
+// ============================================
+
+function analyzeCorridorMatch_CURRENT(drawnGeometry, bufferDistance, minSharedLength, routeFeature) {
+    const geometry = drawnGeometry.type === 'Feature' ? drawnGeometry.geometry : drawnGeometry;
+
+    if (geometry.type !== 'LineString') return { match: false, overlap: 0 };
+
+    const corridorBuffer = turf.buffer(geometry, bufferDistance, { units: 'feet' });
+
+    if (!turf.booleanIntersects(corridorBuffer, routeFeature)) {
+        return { match: false, overlap: 0 };
+    }
+
+    const routeLines = normalizeToLineStrings(routeFeature);
+    let totalOverlap = 0;
+
+    for (const routeLine of routeLines) {
+        const routeCoords = turf.getCoords(routeLine);
+        for (let i = 0; i < routeCoords.length - 1; i++) {
+            const segment = turf.lineString([routeCoords[i], routeCoords[i + 1]]);
+
+            // BUG: Adds FULL segment length, not just portion inside buffer
+            if (turf.booleanIntersects(segment, corridorBuffer)) {
+                totalOverlap += turf.length(segment, { units: 'feet' });
+            }
+        }
+    }
+
+    return {
+        match: totalOverlap >= minSharedLength,
+        overlap: totalOverlap
+    };
+}
+
+// ============================================
+// PROPOSED FIX: Segment Clipping Algorithm
+// ============================================
+
+/**
+ * Calculate the length of a line segment that falls inside a polygon buffer.
+ * Uses polygon boundary intersection to find exact entry/exit points.
+ */
+function measureSegmentInsideBuffer(segment, buffer) {
+    const coords = turf.getCoords(segment);
+    if (coords.length < 2) return 0;
+
+    const startPt = turf.point(coords[0]);
+    const endPt = turf.point(coords[coords.length - 1]);
+    const segmentLength = turf.length(segment, { units: 'feet' });
+
+    if (segmentLength === 0) return 0;
+
+    const startInside = turf.booleanPointInPolygon(startPt, buffer);
+    const endInside = turf.booleanPointInPolygon(endPt, buffer);
+
+    // Case 1: Both endpoints inside - entire segment is inside
+    if (startInside && endInside) {
+        return segmentLength;
+    }
+
+    // Find where segment crosses buffer boundary
+    const bufferBoundary = turf.polygonToLine(buffer);
+    const intersections = turf.lineIntersect(segment, bufferBoundary);
+
+    // Case 2: No boundary crossings
+    if (intersections.features.length === 0) {
+        return startInside ? segmentLength : 0;
+    }
+
+    // Calculate distance along segment for each intersection point
+    const distances = [];
+    for (const pt of intersections.features) {
+        const nearest = turf.nearestPointOnLine(segment, pt, { units: 'feet' });
+        distances.push(nearest.properties.location);
+    }
+
+    // Sort distances from start to end
+    distances.sort((a, b) => a - b);
+
+    // Walk along segment, tracking inside/outside state
+    let totalInside = 0;
+    let inside = startInside;
+    let prevDist = 0;
+
+    for (const dist of distances) {
+        if (inside) {
+            totalInside += dist - prevDist;
+        }
+        prevDist = dist;
+        inside = !inside;
+    }
+
+    // Handle final segment from last crossing to end
+    if (inside) {
+        totalInside += segmentLength - prevDist;
+    }
+
+    return Math.max(0, totalInside);
+}
+
+function analyzeCorridorMatch_FIXED(drawnGeometry, bufferDistance, minSharedLength, routeFeature) {
+    const geometry = drawnGeometry.type === 'Feature' ? drawnGeometry.geometry : drawnGeometry;
+
+    if (geometry.type !== 'LineString') return { match: false, overlap: 0 };
+
+    const corridorBuffer = turf.buffer(geometry, bufferDistance, { units: 'feet' });
+
+    if (!turf.booleanIntersects(corridorBuffer, routeFeature)) {
+        return { match: false, overlap: 0 };
+    }
+
+    const routeLines = normalizeToLineStrings(routeFeature);
+    let totalOverlap = 0;
+
+    for (const routeLine of routeLines) {
+        const routeCoords = turf.getCoords(routeLine);
+
+        for (let i = 0; i < routeCoords.length - 1; i++) {
+            const segment = turf.lineString([routeCoords[i], routeCoords[i + 1]]);
+
+            if (!turf.booleanIntersects(segment, corridorBuffer)) {
+                continue;
+            }
+
+            const insideLength = measureSegmentInsideBuffer(segment, corridorBuffer);
+            totalOverlap += insideLength;
+        }
+
+        if (totalOverlap >= minSharedLength) {
+            break;
+        }
+    }
+
+    return {
+        match: totalOverlap >= minSharedLength,
+        overlap: totalOverlap
+    };
+}
+
+// ============================================
+// TEST UTILITIES
+// ============================================
+
+function createEWLine(centerLon, lat, lengthFeet) {
+    const degreesPerFoot = 1 / 288200;
+    const halfLength = (lengthFeet / 2) * degreesPerFoot;
+    return turf.lineString([
+        [centerLon - halfLength, lat],
+        [centerLon + halfLength, lat]
+    ]);
+}
+
+function createNSLine(lon, centerLat, lengthFeet) {
+    const degreesPerFoot = 1 / 364000;
+    const halfLength = (lengthFeet / 2) * degreesPerFoot;
+    return turf.lineString([
+        [lon, centerLat - halfLength],
+        [lon, centerLat + halfLength]
+    ]);
+}
+
+function createAngledLine(startLon, startLat, lengthFeet, angleDegrees) {
+    const lonDegreesPerFoot = 1 / 288200;
+    const latDegreesPerFoot = 1 / 364000;
+    const angleRad = (angleDegrees * Math.PI) / 180;
+
+    const dx = Math.cos(angleRad) * lengthFeet * lonDegreesPerFoot;
+    const dy = Math.sin(angleRad) * lengthFeet * latDegreesPerFoot;
+
+    return turf.lineString([
+        [startLon, startLat],
+        [startLon + dx, startLat + dy]
+    ]);
+}
+
+function offsetLine(line, offsetFeet, direction = 'north') {
+    const coords = turf.getCoords(line);
+    const latDegreesPerFoot = 1 / 364000;
+    const lonDegreesPerFoot = 1 / 288200;
+
+    const offset = direction === 'north' || direction === 'south'
+        ? offsetFeet * latDegreesPerFoot * (direction === 'north' ? 1 : -1)
+        : offsetFeet * lonDegreesPerFoot * (direction === 'east' ? 1 : -1);
+
+    const newCoords = coords.map(coord => {
+        if (direction === 'north' || direction === 'south') {
+            return [coord[0], coord[1] + offset];
+        } else {
+            return [coord[0] + offset, coord[1]];
+        }
+    });
+
+    return turf.lineString(newCoords);
+}
+
+// ============================================
+// TEST CASES
+// ============================================
+
+const TEST_CASES = [
+    {
+        name: "Parallel route 50ft away, 800ft overlap",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 1000);
+            const route = offsetLine(createEWLine(-90.0, 35.0, 800), 50, 'north');
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: true,
+        expectedOverlapMin: 700,
+        expectedOverlapMax: 850
+    },
+    {
+        name: "Parallel route entirely within buffer (30ft offset)",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 600);
+            const route = offsetLine(createEWLine(-90.0, 35.0, 500), 30, 'north');
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: true,
+        expectedOverlapMin: 480,
+        expectedOverlapMax: 520
+    },
+    {
+        name: "Perpendicular crossing - short route (200ft)",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 500);
+            const route = createNSLine(-90.0, 35.0, 200);
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: false,
+        expectedOverlapMin: 0,
+        expectedOverlapMax: 250
+    },
+    {
+        name: "Perpendicular crossing - long route (500ft) - THE BUG CASE",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 500);
+            const route = createNSLine(-90.0, 35.0, 500);
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: false,
+        expectedOverlapMin: 0,
+        expectedOverlapMax: 250
+    },
+    {
+        name: "Perpendicular crossing - very long route (1000ft)",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 500);
+            const route = createNSLine(-90.0, 35.0, 1000);
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: false,
+        expectedOverlapMin: 0,
+        expectedOverlapMax: 250
+    },
+    {
+        name: "Route entirely outside buffer",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 500);
+            const route = offsetLine(createEWLine(-90.0, 35.0, 500), 200, 'north');
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: false,
+        expectedOverlapMin: 0,
+        expectedOverlapMax: 0
+    },
+    {
+        name: "Short parallel segment (100ft) - below threshold",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 500);
+            const route = offsetLine(createEWLine(-90.0, 35.0, 100), 30, 'north');
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: false,
+        expectedOverlapMin: 50,
+        expectedOverlapMax: 150
+    },
+    {
+        name: "MultiLineString with mixed segments",
+        setup: () => {
+            const project = createEWLine(-90.0, 35.0, 1000);
+            const route = turf.feature({
+                type: 'MultiLineString',
+                coordinates: [
+                    [[-90.001, 35.00008], [-89.9996, 35.00008]],
+                    [[-89.998, 34.999], [-89.998, 35.001]]
+                ]
+            });
+            return { project, route };
+        },
+        bufferDistance: 100,
+        minSharedLength: 300,
+        expectedMatch: true,
+        expectedOverlapMin: 350,
+        expectedOverlapMax: 650
+    }
+];
+
+// ============================================
+// RUN TESTS
+// ============================================
+
+console.log('\n=== Corridor Detection Algorithm Test Suite ===\n');
+
+let passCount = 0;
+let failCount = 0;
+let currentPassCount = 0;
+
+for (const testCase of TEST_CASES) {
+    const { project, route } = testCase.setup();
+
+    const currentResult = analyzeCorridorMatch_CURRENT(
+        project,
+        testCase.bufferDistance,
+        testCase.minSharedLength,
+        route
+    );
+
+    const fixedResult = analyzeCorridorMatch_FIXED(
+        project,
+        testCase.bufferDistance,
+        testCase.minSharedLength,
+        route
+    );
+
+    const matchCorrect = fixedResult.match === testCase.expectedMatch;
+    const overlapInRange = fixedResult.overlap >= testCase.expectedOverlapMin &&
+                           fixedResult.overlap <= testCase.expectedOverlapMax;
+    const passed = matchCorrect && overlapInRange;
+
+    const currentMatchCorrect = currentResult.match === testCase.expectedMatch;
+    const currentOverlapInRange = currentResult.overlap >= testCase.expectedOverlapMin &&
+                                   currentResult.overlap <= testCase.expectedOverlapMax;
+    const currentPassed = currentMatchCorrect && currentOverlapInRange;
+
+    if (passed) passCount++;
+    else failCount++;
+
+    if (currentPassed) currentPassCount++;
+
+    const icon = passed ? '✓' : '✗';
+    const color = passed ? '\x1b[32m' : '\x1b[31m';
+    const reset = '\x1b[0m';
+
+    console.log(`${color}${icon}${reset} ${testCase.name}`);
+    console.log(`  Expected: match=${testCase.expectedMatch}, overlap=${testCase.expectedOverlapMin}-${testCase.expectedOverlapMax}ft`);
+    console.log(`  Current:  match=${currentResult.match}, overlap=${currentResult.overlap.toFixed(1)}ft ${currentPassed ? '✓' : '✗'}`);
+    console.log(`  Fixed:    match=${fixedResult.match}, overlap=${fixedResult.overlap.toFixed(1)}ft ${passed ? '✓' : '✗'}`);
+    console.log('');
+}
+
+console.log('=== SUMMARY ===');
+console.log(`Current algorithm: ${currentPassCount}/${TEST_CASES.length} passing`);
+console.log(`Fixed algorithm:   ${passCount}/${TEST_CASES.length} passing`);
+console.log('');
+
+if (failCount > 0) {
+    console.log('\x1b[31mSome tests failed!\x1b[0m');
+    process.exit(1);
+} else {
+    console.log('\x1b[32mAll tests passed!\x1b[0m');
+    process.exit(0);
+}


### PR DESCRIPTION
## Problem
The corridor matching algorithm was incorrectly counting the full length of route segments when they intersected the buffer, instead of only the portion actually inside the buffer. This caused perpendicular crossings to generate false positives:
- A 500ft north-south route crossing an east-west project would count 500ft instead of ~200ft (the actual buffer width), exceeding the 300ft threshold

## Solution
Implemented segment clipping algorithm using buffer boundary intersection:
1. Detect entry/exit points where segment crosses buffer boundary
2. Calculate distance along segment for each crossing point
3. Sum only the portions between inside/outside state changes
4. Correctly handles:
   - Segments entirely inside buffer (count full length)
   - Segments crossing boundary multiple times (perpendicular crossings)
   - Segments partially inside (count only inside portion)
   - MultiLineString geometries with mixed segment types

## Implementation
- Added measureSegmentInsideBuffer() function (lines 1981-2040)
- Updated analyzeCorridorMatch() to use new function (lines 2115-2122)
- Prevents false positives while maintaining true parallel route detection

## Testing
- Created comprehensive test suite (test-corridor-detection.html)
  - 8 test cases covering parallel routes, perpendicular crossings, edge cases
  - Compares current (broken) vs. fixed algorithm behavior
- Node.js test runner included (test-corridor-node.js)

## Algorithm Details
Uses Turf.js functions for geometric operations:
- turf.booleanPointInPolygon(): Check if endpoints are inside buffer
- turf.polygonToLine(): Get buffer boundary
- turf.lineIntersect(): Find where segment crosses boundary
- turf.nearestPointOnLine(): Calculate distance along segment

🤖 Generated with Claude Code