### PR TITLE
fix: resolve zoom extent and layer organization issues (v0.7.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Memphis MPO Project Application Tool
 
-![Version](https://img.shields.io/badge/version-0.7.0-blue) ![Status](https://img.shields.io/badge/status-in%20development-yellow)
+![Version](https://img.shields.io/badge/version-0.7.1-blue) ![Status](https://img.shields.io/badge/status-in%20development-yellow)
 
-**⚠️ This tool is currently in active development (v0.7.0) and not yet released for production use.**
+**⚠️ This tool is currently in active development (v0.7.1) and not yet released for production use.**
 
 A web-based mapping tool for analyzing transportation project proposals against regional planning datasets. Built for the Memphis Metropolitan Planning Organization's Regional Transportation Plan (RTP) 2055.
 
@@ -12,7 +12,7 @@ A web-based mapping tool for analyzing transportation project proposals against 
 
 This tool allows users to draw project alignments or mark specific locations on an interactive map, then automatically identifies intersecting or nearby transportation infrastructure and planning features. The tool generates a PDF report summarizing the spatial relationships between the proposed project and key regional datasets.
 
-**Current Status (v0.7.0):** Codebase refactored into modular architecture with 7 separate files for improved maintainability. Core spatial analysis engine supports 12 datasets across multiple geometry types using a scalable, configuration-driven system. Significant work remains before v1.0 release:
+**Current Status (v0.7.1):** Codebase refactored into modular architecture with 7 separate files for improved maintainability. Layers now grouped by topic (Transportation, Economic, Environmental) for better organization. Core spatial analysis engine supports 12 datasets across multiple geometry types using a scalable, configuration-driven system. Significant work remains before v1.0 release:
 - Integration of remaining ~7 required regional planning datasets
 - User experience improvements and documentation
 - Potential ArcGIS Feature Service integration for large datasets
@@ -43,7 +43,7 @@ The tool performs automated spatial analysis using three different methods:
 - Creates configurable buffer around drawn geometry
 - Identifies all features within specified distance
 
-**Current implementation (v0.7.0)** analyzes against 12 datasets:
+**Current implementation (v0.7.1)** analyzes against 12 datasets:
 - **MATA Routes** - Transit route network
 - **STRAHNET Routes** - Strategic Highway Network
 - **MPO Freight Route Network** - Regional/local freight routes with color-coding
@@ -69,7 +69,7 @@ The tool performs automated spatial analysis using three different methods:
 
 ## Data Requirements
 
-### Implemented Datasets (v0.7.0)
+### Implemented Datasets (v0.7.1)
 
 **Transportation:**
 - ✅ **MATA Routes** (lines) - Transit route network
@@ -150,7 +150,7 @@ The tool performs automated spatial analysis using three different methods:
 
 ### Architecture
 
-**Modular JavaScript Application (v0.7.0)** with 7 focused files:
+**Modular JavaScript Application (v0.7.1)** with 7 focused files:
 
 **Core Files:**
 - **index.html** (~140 lines) - HTML structure and script tags only
@@ -296,7 +296,7 @@ project-application-tool/
 
 ### Adding New Datasets
 
-**Current approach (v0.7.0)** - configuration-driven:
+**Current approach (v0.7.1)** - configuration-driven:
 
 1. **Add GeoJSON file to `/data/` directory**
 
@@ -340,7 +340,7 @@ newDataset: {
 
 ## Known Limitations
 
-**Development Status (v0.7.0):**
+**Development Status (v0.7.1):**
 - 12 of ~19 required datasets currently integrated
 - Large datasets (Congested Segments, Crash Locations) may require ArcGIS Feature Service integration
 - Some specialized analysis logic (crash counting, ALICE criteria) not yet implemented
@@ -354,6 +354,12 @@ newDataset: {
 - Analysis runs synchronously (may cause brief UI freeze on very large projects)
 
 ## Development Roadmap
+
+### v0.7.1 - Completed ✅
+- ✅ **Fixed zoom and layer organization issues**
+  - Fixed zoom extent to show Memphis area instead of continental US
+  - Grouped layers by topic (Transportation, Economic, Environmental)
+  - Fixed freight routes display symbol (MultiLineString support)
 
 ### v0.7.0 - Completed ✅
 - ✅ **Refactored monolithic index.html into modular architecture**

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,19 @@
 # Version History
 
+## v0.7.1 (2025-12-29)
+- Fixed zoom extent to show Memphis area instead of continental US
+- Grouped layers by topic (Transportation, Economic, Environmental) in map view
+- Fixed freight routes display symbol from points to lines (MultiLineString support)
+
+### Bug Fixes
+- **Zoom extent**: Changed `fitMapToBounds()` to use fixed Memphis MPO bounds [34.9, -90.1] to [35.3, -89.6] instead of calculating from all layers
+- **Layer grouping**: Reorganized layer control with visual category headers (Transportation, Economic, Environmental)
+- **Freight routes symbol**: Added MultiLineString check in symbol selection to display '─' (line) instead of '●' (point)
+
+### Configuration Changes
+- Updated dataset categories to use simplified grouping (Transportation, Economic, Environmental)
+- Layer control now displays grouped overlays with category headers and indented layer names
+
 ## v0.7.0 (2025-12-29)
 - Refactored monolithic index.html into 7 modular files
 - No functional changes to user experience

--- a/datasets.js
+++ b/datasets.js
@@ -44,7 +44,7 @@ const DATASETS = {
   mataRoutes: {
     id: 'mataRoutes',
     name: 'MATA Routes',
-    category: 'Transportation - Transit',
+    category: 'Transportation',
     filePath: './data/mata-routes.json',
     geometryType: 'LineString',
     analysisMethod: 'corridor',
@@ -71,7 +71,7 @@ const DATASETS = {
   strahnet: {
     id: 'strahnet',
     name: 'STRAHNET Routes',
-    category: 'Transportation - Freight',
+    category: 'Transportation',
     filePath: './data/strahnet.geojson',
     geometryType: 'LineString',
     analysisMethod: 'corridor',
@@ -99,7 +99,7 @@ const DATASETS = {
   truckRoutes: {
     id: 'truckRoutes',
     name: 'MPO Freight Route Network',
-    category: 'Transportation - Freight',
+    category: 'Transportation',
     filePath: './data/truck_routes.json',
     geometryType: 'MultiLineString',
     analysisMethod: 'corridor',
@@ -133,7 +133,7 @@ const DATASETS = {
   opportunityZones: {
     id: 'opportunityZones',
     name: 'Opportunity Zones',
-    category: 'Economic Development',
+    category: 'Economic',
     filePath: './data/opportunity-zones.json',
     geometryType: 'Polygon',
     analysisMethod: 'intersection',
@@ -161,7 +161,7 @@ const DATASETS = {
   freightClusters: {
     id: 'freightClusters',
     name: 'MPO Freight Zones',
-    category: 'Transportation - Freight',
+    category: 'Transportation',
     filePath: './data/freight_clusters.geojson',
     geometryType: 'Polygon',
     analysisMethod: 'intersection',
@@ -189,7 +189,7 @@ const DATASETS = {
   parks: {
     id: 'parks',
     name: 'Parks',
-    category: 'Environment & Recreation',
+    category: 'Environmental',
     filePath: './data/parks.json',
     geometryType: 'Polygon',
     analysisMethod: 'proximity',
@@ -217,7 +217,7 @@ const DATASETS = {
   historicPolygons: {
     id: 'historicPolygons',
     name: 'NHRP Polygons',
-    category: 'Historic & Cultural',
+    category: 'Environmental',
     filePath: './data/historic_polygons.geojson',
     geometryType: 'Polygon',
     analysisMethod: 'proximity',
@@ -245,7 +245,7 @@ const DATASETS = {
   bridges: {
     id: 'bridges',
     name: 'Bridges',
-    category: 'Infrastructure',
+    category: 'Transportation',
     filePath: './data/bridges.json',
     geometryType: 'Point',
     analysisMethod: 'proximity',
@@ -274,7 +274,7 @@ const DATASETS = {
   majorEmployers: {
     id: 'majorEmployers',
     name: 'Major Employers',
-    category: 'Economic Development',
+    category: 'Economic',
     filePath: './data/major_employers.geojson',
     geometryType: 'Point',
     analysisMethod: 'proximity',
@@ -303,7 +303,7 @@ const DATASETS = {
   touristAttractions: {
     id: 'touristAttractions',
     name: 'Tourist Destinations',
-    category: 'Economic Development',
+    category: 'Economic',
     filePath: './data/tourist_attractions.geojson',
     geometryType: 'Point',
     analysisMethod: 'proximity',
@@ -332,7 +332,7 @@ const DATASETS = {
   historicPoints: {
     id: 'historicPoints',
     name: 'NHRP Points',
-    category: 'Historic & Cultural',
+    category: 'Environmental',
     filePath: './data/historic_points.geojson',
     geometryType: 'Point',
     analysisMethod: 'proximity',
@@ -361,7 +361,7 @@ const DATASETS = {
   epaSuperFundSites: {
     id: 'epaSuperFundSites',
     name: 'EPA Superfund Sites',
-    category: 'Environment & Recreation',
+    category: 'Environmental',
     filePath: './data/epa_superfund_sites.geojson',
     geometryType: 'Point',
     analysisMethod: 'proximity',

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Memphis MPO - Project Application Tool v0.7.0</title>
+  <title>Memphis MPO - Project Application Tool v0.7.1</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- Leaflet CSS for map rendering -->
@@ -135,10 +135,10 @@
   <script src="https://unpkg.com/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 
   <!-- Application Scripts (load in order) -->
-  <script src="datasets.js?v=0.7.0"></script>
-  <script src="map.js?v=0.7.0"></script>
-  <script src="analysis.js?v=0.7.0"></script>
-  <script src="pdf.js?v=0.7.0"></script>
-  <script src="app.js?v=0.7.0"></script>
+  <script src="datasets.js?v=0.7.1"></script>
+  <script src="map.js?v=0.7.1"></script>
+  <script src="analysis.js?v=0.7.1"></script>
+  <script src="pdf.js?v=0.7.1"></script>
+  <script src="app.js?v=0.7.1"></script>
 </body>
 </html>


### PR DESCRIPTION
- Fixed zoom extent to show Memphis MPO area instead of continental US
  - Changed fitMapToBounds() to use fixed bounds [34.9, -90.1] to [35.3, -89.6]
  - Replaced dynamic bounds calculation with static Memphis region

- Grouped layers by topic in map view
  - Reorganized layer control with category headers (Transportation, Economic, Environmental)
  - Updated all dataset categories to simplified grouping
  - Added visual indentation for layers under category headers

- Fixed freight routes display symbol
  - Added MultiLineString check in symbol selection
  - Freight routes now show as lines (─) instead of points (●)

- Updated documentation to version 0.7.1
  - Updated VERSION.md with detailed change log
  - Updated README.md version badges and references
  - Updated index.html title and cache-busting parameters